### PR TITLE
Hazelcast Client 4.0.1 for base 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   },
   "author": "",
   "dependencies": {
-    "hazelcast-client": "^4.0.0"
+    "hazelcast-client": "^4.0.1"
   }
 }


### PR DESCRIPTION
This pull request updates the Hazelcast Client version to `4.0.1` which includes several bug fixes.
It is tested on Starter Cluster with version 4.0.2 and TLS enabled.