### PR TITLE
HZC-3278: Rollback the HZ_CLOUD_COORDINATOR_BASE_URL setting removal

### DIFF
--- a/client.js
+++ b/client.js
@@ -274,7 +274,12 @@ async function nonStopMapExample(client) {
                         discoveryToken: 'YOUR_CLUSTER_DISCOVERY_TOKEN'
                     }
                 },
-                clusterName: 'YOUR_CLUSTER_NAME'
+                clusterName: 'YOUR_CLUSTER_NAME',
+                properties: {
+                    'hazelcast.client.cloud.url': 'YOUR_DISCOVERY_URL',
+                    'hazelcast.client.statistics.enabled': true,
+                    'hazelcast.client.statistics.period.seconds': 1,
+                }
             }
         );
         console.log("Connection Successful!");

--- a/client_with_ssl.js
+++ b/client_with_ssl.js
@@ -287,7 +287,12 @@ async function nonStopMapExample(client) {
                         }
                     }
                 },
-                clusterName: 'YOUR_CLUSTER_NAME'
+                clusterName: 'YOUR_CLUSTER_NAME',
+                properties: {
+                    'hazelcast.client.cloud.url': 'YOUR_DISCOVERY_URL',
+                    'hazelcast.client.statistics.enabled': true,
+                    'hazelcast.client.statistics.period.seconds': 1,
+                }
             }
         );
         console.log("Connection Successful!");


### PR DESCRIPTION
```
npm run client_with_ssl

> hazelcast-cloud-nodejs-sample-client@1.0.0 client_with_ssl
> npm install && node client_with_ssl.js

up to date, audited 4 packages in 732ms
found 0 vulnerabilities

[DefaultLogger] INFO at LifecycleService: HazelcastClient is STARTING
[DefaultLogger] INFO at LifecycleService: HazelcastClient is STARTED
[DefaultLogger] INFO at ConnectionManager: Trying to connect to 10.7.213.76:30000
[DefaultLogger] INFO at LifecycleService: HazelcastClient is CONNECTED
[DefaultLogger] INFO at ConnectionManager: Authenticated with server 10.7.213.76:30000:dad83373-4219-4f43-97f0-222085e22f99, server version: 5.1.1, local address: 10.253.248.43:52564
[DefaultLogger] INFO at ClusterService:

Members [1] {
	Member [10.7.213.76]:30000 - dad83373-4219-4f43-97f0-222085e22f99
}

[DefaultLogger] INFO at Statistics: Client statistics is enabled with period 1 seconds.
Connection Successful!
'cities' map now contains 16 entries.
--------------------
[DefaultLogger] INFO at LifecycleService: HazelcastClient is SHUTTING_DOWN
[DefaultLogger] INFO at ConnectionManager: Removed connection to endpoint: 10.7.213.76:30000:dad83373-4219-4f43-97f0-222085e22f99, connection: Connection{alive=false, connectionId=0, remoteAddress=10.7.213.76:30000}
[DefaultLogger] INFO at LifecycleService: HazelcastClient is DISCONNECTED
[DefaultLogger] INFO at LifecycleService: HazelcastClient is SHUTDOWN
```